### PR TITLE
my_package: 0.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9,6 +9,11 @@ release_platforms:
   - noble
 repositories:
   my_package:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/tgenovese/my_package-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/tgenovese/my_package.git


### PR DESCRIPTION
Increasing version of package(s) in repository `my_package` to `0.0.1-1`:

- upstream repository: https://github.com/tgenovese/my_package.git
- release repository: https://github.com/tgenovese/my_package-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## my_package

```
* Initial package
* Contributors: Thierry Genovese
```
