### PR TITLE
my_package: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7,6 +7,11 @@ release_platforms:
   - jammy
 repositories:
   my_package:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/tgenovese/my_package-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/tgenovese/my_package.git


### PR DESCRIPTION
Increasing version of package(s) in repository `my_package` to `0.0.1-1`:

- upstream repository: https://github.com/tgenovese/my_package.git
- release repository: https://github.com/tgenovese/my_package-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## my_package

```
* Initial package
* Contributors: Thierry Genovese
```
