### PR TITLE
my_package: 0.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -12,7 +12,7 @@ repositories:
     release:
       tags:
         release: release/kilted/{package}/{version}
-      url: git@github.com:tgenovese/my_package-release.git
+      url: https://github.com/tgenovese/my_package-release.git
       version: 0.0.1-1
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `my_package` to `0.0.1-1`:

- upstream repository: https://github.com/tgenovese/my_package.git
- release repository: git@github.com:tgenovese/my_package-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## my_package

```
* Initial package
* Contributors: Thierry Genovese
```
