### PR TITLE
mimick_vendor: 0.6.2-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -17,7 +17,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/mimick_vendor-release.git
-      version: 0.6.2-1
+      version: 0.6.2-2
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.6.2-2`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/tgenovese/mimick_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.6.2-1`

## mimick_vendor

```
* Update to the commit that includes DT_GNU_HASH. (#37 <https://github.com/ros2/mimick_vendor/issues/37>) (#38 <https://github.com/ros2/mimick_vendor/issues/38>)
  (cherry picked from commit c9f8b35ce5a5c5d237c7a2db2591976f0b7cba2a)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
