### PR TITLE
spdlog_vendor: 1.6.1-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -39,7 +39,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/spdlog_vendor-release.git
-      version: 1.6.1-1
+      version: 1.6.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spdlog_vendor` to `1.6.1-2`:

- upstream repository: https://github.com/ros2/spdlog_vendor.git
- release repository: https://github.com/tgenovese/spdlog_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.6.1-1`

## spdlog_vendor

```
* Removed spdlog_vendor warnings (#36 <https://github.com/ros2/spdlog_vendor/issues/36>) (#37 <https://github.com/ros2/spdlog_vendor/issues/37>)
  (cherry picked from commit 4510d9ab4389f84daac77210f3fdf8aab372b938)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
