### PR TITLE
console_bridge_vendor: 1.7.1-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -17,7 +17,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/console_bridge_vendor-release.git
-      version: 1.7.1-3
+      version: 1.7.1-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `console_bridge_vendor` to `1.7.1-4`:

- upstream repository: https://github.com/ros2/console_bridge_vendor.git
- release repository: https://github.com/tgenovese/console_bridge_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.7.1-3`
