### PR TITLE
libyaml_vendor: 1.6.3-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -29,7 +29,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/libyaml_vendor-release.git
-      version: 1.6.3-2
+      version: 1.6.3-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.6.3-3`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/tgenovese/libyaml_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.6.3-2`

## libyaml_vendor

```
* Update quality declaration documents (#62 <https://github.com/ros2/libyaml_vendor/issues/62>)
* Contributors: Christophe Bedard
```
