### PR TITLE
ros2_tracing: 8.2.3-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -79,7 +79,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/ros2_tracing-release.git
-      version: 8.2.3-2
+      version: 8.2.3-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.2.3-3`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/tgenovese/ros2_tracing-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `8.2.3-2`

## lttngpy

```
* Add missing dependency on pkg-config to lttngpy (#130 <https://github.com/ros2/ros2_tracing/issues/130>) (#136 <https://github.com/ros2/ros2_tracing/issues/136>)
  (cherry picked from commit a866b9c701311bc8200a00c949b4a0fff9803777)
  Co-authored-by: Nathan Wiebe Neufeldt <mailto:wn.nathan@gmail.com>
* Contributors: mergify[bot]
```

## ros2trace

- No changes

## tracetools

- No changes

## tracetools_launch

- No changes

## tracetools_read

- No changes

## tracetools_test

- No changes

## tracetools_trace

- No changes
