### PR TITLE
class_loader: 2.7.0-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -16,9 +16,8 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      # Regenerated outdated debian files with bloom-release
       url: https://github.com/tgenovese/class_loader-release.git
-      version: 2.7.0-3
+      version: 2.7.0-4
     source:
       test_pull_requests: true
       type: git
@@ -33,7 +32,6 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      # Regenerated outdated debian files with bloom-release
       url: https://github.com/tgenovese/console_bridge_vendor-release.git
       version: 1.7.1-4
     source:
@@ -46,7 +44,6 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      # Regenerated outdated debian files with bloom-release
       url: https://github.com/tgenovese/libyaml_vendor-release.git
       version: 1.6.3-3
     source:
@@ -63,7 +60,6 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      # Regenerated outdated debian files with bloom-release
       url: https://github.com/tgenovese/mimick_vendor-release.git
       version: 0.6.2-2
     source:
@@ -98,7 +94,6 @@ repositories:
       - tracetools_trace
       tags:
         release: release/jazzy/{package}/{version}
-      # Added a missing dependency on ament_cmake to tracetools
       url: https://github.com/tgenovese/ros2_tracing-release.git
       version: 8.2.3-3
     source:
@@ -111,7 +106,6 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      # Regenerated outdated debian files with bloom-release
       url: https://github.com/tgenovese/spdlog_vendor-release.git
       version: 1.6.1-2
     source:


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.7.0-4`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/tgenovese/class_loader-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.0-3`

## class_loader

```
* Remove all uses of ament_target_dependencies. (#210 <https://github.com/ros/class_loader/issues/210>)
* Update to C++17 (#209 <https://github.com/ros/class_loader/issues/209>)
* Contributors: Chris Lalancette
```
