### PR TITLE
rmw_implementation: 2.15.5-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -87,7 +87,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/rmw_implementation-release.git
-      version: 2.15.5-1
+      version: 2.15.5-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `2.15.5-2`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/tgenovese/rmw_implementation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.15.5-1`

## rmw_implementation

```
* Added rmw_event_type_is_supported (#250 <https://github.com/ros2/rmw_implementation/issues/250>) (#252 <https://github.com/ros2/rmw_implementation/issues/252>)
* Contributors: Alejandro Hernández Cordero
```
