### PR TITLE
rclcpp: 28.1.10-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -92,7 +92,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/rclcpp-release.git
-      version: 28.1.10-1
+      version: 28.1.10-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.1.10-2`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/tgenovese/rclcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `28.1.10-1`

## rclcpp

```
* Fix for memory leaks in rclcpp::SerializedMessage (#2861 <https://github.com/ros2/rclcpp/issues/2861>) (#2864 <https://github.com/ros2/rclcpp/issues/2864>)
* Added missing chrono includes (#2854 <https://github.com/ros2/rclcpp/issues/2854>) (#2856 <https://github.com/ros2/rclcpp/issues/2856>)
* get_all_data_impl() does not handle null pointers properly, causing segmentation fault (backport #2840 <https://github.com/ros2/rclcpp/issues/2840>) (#2851 <https://github.com/ros2/rclcpp/issues/2851>)
* QoSInitialization::from_rmw does not validate invalid history policy values, leading to silent failures (#2841 <https://github.com/ros2/rclcpp/issues/2841>) (#2845 <https://github.com/ros2/rclcpp/issues/2845>)
* throws std::invalid_argument if ParameterEvent is NULL. (#2814 <https://github.com/ros2/rclcpp/issues/2814>) (#2825 <https://github.com/ros2/rclcpp/issues/2825>)
* Merge pull request #2821 <https://github.com/ros2/rclcpp/issues/2821> from ros2/mergify/bp/jazzy/pr-2819
* Fix race condition (#2819 <https://github.com/ros2/rclcpp/issues/2819>)
* Contributors: Michael Orlov, Pedro de Azeredo, mergify[bot]
```

## rclcpp_action

```
* Replace std::default_random_engine with std::mt19937 (humble) (#2847 <https://github.com/ros2/rclcpp/issues/2847>) (#2867 <https://github.com/ros2/rclcpp/issues/2867>)
* Added missing chrono includes (#2854 <https://github.com/ros2/rclcpp/issues/2854>) (#2856 <https://github.com/ros2/rclcpp/issues/2856>)
* Contributors: mergify[bot]
```

## rclcpp_components

```
* Added missing chrono includes (#2854 <https://github.com/ros2/rclcpp/issues/2854>) (#2856 <https://github.com/ros2/rclcpp/issues/2856>)
* Contributors: mergify[bot]
```

## rclcpp_lifecycle

```
* Added missing chrono includes (#2854 <https://github.com/ros2/rclcpp/issues/2854>) (#2856 <https://github.com/ros2/rclcpp/issues/2856>)
* Contributors: mergify[bot]
```
