### PR TITLE
urdf: 2.10.0-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -194,7 +194,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/urdf-release.git
-      version: 2.10.0-3
+      version: 2.10.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.10.0-4`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/tgenovese/urdf-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.10.0-3`

## urdf

```
* Switch to target_link_libraries (#36 <https://github.com/ros2/urdf/issues/36>)
* Contributors: Chris Lalancette
```

## urdf_parser_plugin

```
* Switch to target_link_libraries (#36 <https://github.com/ros2/urdf/issues/36>)
* Contributors: Chris Lalancette
```
