### PR TITLE
robot_state_publisher: 3.3.3-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -155,7 +155,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/robot_state_publisher-release.git
-      version: 3.3.3-3
+      version: 3.3.3-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `3.3.3-4`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/tgenovese/robot_state_publisher-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.3.3-3`

## robot_state_publisher

```
* Fix reload after a description with a mimic joint (#212 <https://github.com/ros/robot_state_publisher/issues/212>)
* Contributors: Guillaume Doisy
```
