### PR TITLE
diagnostics: 4.2.6-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -56,7 +56,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/diagnostics-release.git
-      version: 4.2.6-1
+      version: 4.2.6-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `4.2.6-2`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/tgenovese/diagnostics-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.2.6-1`

## diagnostic_aggregator

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```

## diagnostic_common_diagnostics

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```

## diagnostic_remote_logging

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```

## diagnostic_updater

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```

## diagnostics

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```

## self_test

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```
