### PR TITLE
image_transport_plugins: 4.0.5-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -78,7 +78,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/image_transport_plugins-release.git
-      version: 4.0.5-1
+      version: 4.0.5-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `4.0.5-2`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/tgenovese/image_transport_plugins-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.5-1`

## compressed_depth_image_transport

```
* Use non deprecated method (#182 <https://github.com/ros-perception/image_transport_plugins/issues/182>) (#194 <https://github.com/ros-perception/image_transport_plugins/issues/194>)
* Contributors: mergify[bot]
```

## compressed_image_transport

```
* Use non deprecated method (#182 <https://github.com/ros-perception/image_transport_plugins/issues/182>) (#194 <https://github.com/ros-perception/image_transport_plugins/issues/194>)
* Contributors: mergify[bot]
```

## image_transport_plugins

- No changes

## theora_image_transport

```
* Use non deprecated method (#182 <https://github.com/ros-perception/image_transport_plugins/issues/182>) (#194 <https://github.com/ros-perception/image_transport_plugins/issues/194>)
* Contributors: mergify[bot]
```

## zstd_image_transport

```
* Use non deprecated method (#182 <https://github.com/ros-perception/image_transport_plugins/issues/182>) (#194 <https://github.com/ros-perception/image_transport_plugins/issues/194>)
* Adding the include of cstdint (#189 <https://github.com/ros-perception/image_transport_plugins/issues/189>) (#190 <https://github.com/ros-perception/image_transport_plugins/issues/190>)
* Contributors: mergify[bot]
```
