### PR TITLE
angles: 1.16.0-6 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -36,7 +36,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/angles-release.git
-      version: 1.16.0-5
+      version: 1.16.0-6
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.16.0-6`:

- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/tgenovese/angles-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.16.0-5`

## angles

```
* Correct versions for version bump
* ROS 2 Python Port (#37 <https://github.com/ros/angles/issues/37>)
* Fix M_PI on Windows (#34 <https://github.com/ros/angles/issues/34>)
* Contributors: Akash, David V. Lu!!, Geoffrey Biggs
```
