### PR TITLE
rosidl_core: 0.2.0-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -289,7 +289,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/rosidl_core-release.git
-      version: 0.2.0-3
+      version: 0.2.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_core` to `0.2.0-4`:

- upstream repository: https://github.com/ros2/rosidl_core.git
- release repository: https://github.com/tgenovese/rosidl_core-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.0-3`

## rosidl_core_generators

- No changes

## rosidl_core_runtime

- No changes
