### PR TITLE
navigation_msgs: 2.4.1-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -152,7 +152,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/navigation_msgs-release.git
-      version: 2.4.1-2
+      version: 2.4.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_msgs` to `2.4.1-3`:

- upstream repository: https://github.com/ros-planning/navigation_msgs
- release repository: https://github.com/tgenovese/navigation_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.1-2`

## map_msgs

```
* Update maintainer list in package.xml files
* Contributors: Michael Jeronimo, Steve Macenski
```
