### PR TITLE
eigen3_cmake_module: 0.3.0-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -145,7 +145,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/eigen3_cmake_module-release.git
-      version: 0.3.0-3
+      version: 0.3.0-4
     source:
       type: git
       url: https://github.com/ros2/eigen3_cmake_module.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen3_cmake_module` to `0.3.0-4`:

- upstream repository: https://github.com/ros2/eigen3_cmake_module.git
- release repository: https://github.com/tgenovese/eigen3_cmake_module-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.0-3`

## eigen3_cmake_module

- No changes
