### PR TITLE
example_interfaces: 0.12.0-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -160,7 +160,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/example_interfaces-release.git
-      version: 0.12.0-3
+      version: 0.12.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `example_interfaces` to `0.12.0-4`:

- upstream repository: https://github.com/ros2/example_interfaces.git
- release repository: https://github.com/tgenovese/example_interfaces-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.12.0-3`

## example_interfaces

```
* Update to C++17. (#18 <https://github.com/ros2/example_interfaces/issues/18>)
* Contributors: Chris Lalancette
```
