### PR TITLE
foonathan_memory_vendor: 1.3.1-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -172,7 +172,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/foonathan_memory_vendor-release.git
-      version: 1.3.1-3
+      version: 1.3.1-4
     source:
       type: git
       url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foonathan_memory_vendor` to `1.3.1-4`:

- upstream repository: https://github.com/eProsima/foonathan_memory_vendor.git
- release repository: https://github.com/tgenovese/foonathan_memory_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.1-3`

## foonathan_memory_vendor

```
* Added support for QNX 7.1 build (#65)
```
