### PR TITLE
joystick_drivers: 3.3.0-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -194,7 +194,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/joystick_drivers-release.git
-      version: 3.3.0-3
+      version: 3.3.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `3.3.0-4`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/tgenovese/joystick_drivers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.3.0-3`

## joy

```
* Fix compatibility with SDL versions below 2.0.18 (#273 <https://github.com/ros-drivers/joystick_drivers/issues/273>)
* Contributors: Johannes Meyer
```

## joy_linux

- No changes

## sdl2_vendor

```
* Upgrade to SDL2.0.20 (#270 <https://github.com/ros-drivers/joystick_drivers/issues/270>)
* Contributors: Patrick Roncagliolo
```

## spacenav

- No changes

## wiimote

- No changes

## wiimote_msgs

- No changes
