### PR TITLE
keyboard_handler: 0.3.1-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -226,7 +226,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/keyboard_handler-release.git
-      version: 0.3.1-2
+      version: 0.3.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `keyboard_handler` to `0.3.1-3`:

- upstream repository: https://github.com/ros-tooling/keyboard_handler.git
- release repository: https://github.com/tgenovese/keyboard_handler-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.1-2`

## keyboard_handler

```
* Shorten lambdas so newer uncrustify is happier. (#42 <https://github.com/ros-tooling/keyboard_handler/issues/42>)
* Fixed C++20 warning implicit capture of this in lambda (#41 <https://github.com/ros-tooling/keyboard_handler/issues/41>)
* Contributors: AiVerisimilitude, Chris Lalancette
```
