### PR TITLE
pluginlib: 5.4.2-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -325,7 +325,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/pluginlib-release.git
-      version: 5.4.2-2
+      version: 5.4.2-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.4.2-3`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/tgenovese/pluginlib-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.4.2-2`

## pluginlib

```
* Switch from rcpputils::fs to std::filesystem (#254 <https://github.com/ros/pluginlib/issues/254>)
* Contributors: Christophe Bedard
```
