### PR TITLE
python_qt_binding: 2.2.1-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -356,7 +356,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/python_qt_binding-release.git
-      version: 2.2.1-1
+      version: 2.2.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `2.2.1-2`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/tgenovese/python_qt_binding-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.1-1`

## python_qt_binding

```
* Suppress warning from Shiboken2. (backport #137 <https://github.com/ros-visualization/python_qt_binding/issues/137>) (#138 <https://github.com/ros-visualization/python_qt_binding/issues/138>)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
