### PR TITLE
test_interface_files: 0.11.0-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -558,7 +558,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/test_interface_files-release.git
-      version: 0.11.0-3
+      version: 0.11.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `test_interface_files` to `0.11.0-4`:

- upstream repository: https://github.com/ros2/test_interface_files.git
- release repository: https://github.com/tgenovese/test_interface_files-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.11.0-3`

## test_interface_files

- No changes
