### PR TITLE
tinyxml2_vendor: 0.9.1-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -574,7 +574,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/tinyxml2_vendor-release.git
-      version: 0.9.1-3
+      version: 0.9.1-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyxml2_vendor` to `0.9.1-4`:

- upstream repository: https://github.com/ros2/tinyxml2_vendor.git
- release repository: https://github.com/tgenovese/tinyxml2_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.9.1-3`
