### PR TITLE
unique_identifier_msgs: 2.5.0-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -606,7 +606,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/unique_identifier_msgs-release.git
-      version: 2.5.0-3
+      version: 2.5.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier_msgs` to `2.5.0-4`:

- upstream repository: https://github.com/ros2/unique_identifier_msgs.git
- release repository: https://github.com/tgenovese/unique_identifier_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.5.0-3`

## unique_identifier_msgs

```
* Update to C++17 (#27 <https://github.com/ros2/unique_identifier_msgs/issues/27>)
* Contributors: Chris Lalancette
```
