### PR TITLE
ros_testing: 0.6.0-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -465,7 +465,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/ros_testing-release.git
-      version: 0.6.0-3
+      version: 0.6.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_testing` to `0.6.0-4`:

- upstream repository: https://github.com/ros2/ros_testing.git
- release repository: https://github.com/tgenovese/ros_testing-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.6.0-3`

## ros2test

- No changes

## ros_testing

- No changes
