### PR TITLE
ros2cli_common_extensions: 0.3.0-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -447,7 +447,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/ros2cli_common_extensions-release.git
-      version: 0.3.0-3
+      version: 0.3.0-4
     source:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli_common_extensions` to `0.3.0-4`:

- upstream repository: https://github.com/ros2/ros2cli_common_extensions.git
- release repository: https://github.com/tgenovese/ros2cli_common_extensions-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.0-3`

## ros2cli_common_extensions

- No changes
