### PR TITLE
rqt: 1.6.0-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -591,7 +591,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/rqt-release.git
-      version: 1.6.0-2
+      version: 1.6.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.6.0-3`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/tgenovese/rqt-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.6.0-2`

## rqt

```
* Add a test dependency on pytest. (#306 <https://github.com/ros-visualization/rqt/issues/306>)
* Contributors: Chris Lalancette
```

## rqt_gui

- No changes

## rqt_gui_cpp

- No changes

## rqt_gui_py

- No changes

## rqt_py_common

```
* Allow to autocomplete namespaced topics (#299 <https://github.com/ros-visualization/rqt/issues/299>)
* Contributors: Alejandro Hernández Cordero
```
