### PR TITLE
ros_tutorials: 1.8.3-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -499,7 +499,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/ros_tutorials-release.git
-      version: 1.8.3-1
+      version: 1.8.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `1.8.3-2`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/tgenovese/ros_tutorials-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.8.3-1`

## turtlesim

```
* Add icon for Jazzy. (#167 <https://github.com/ros/ros_tutorials/issues/167>) (#168 <https://github.com/ros/ros_tutorials/issues/168>)
  (cherry picked from commit 014955e15a6ac3b1649cbf21e11c8547ebd47af7)
  Co-authored-by: Marco A. Gutierrez <mailto:marcogg@marcogg.com>
* [teleop_turtle_key] update usage string to match keys captured by keyboard (#165 <https://github.com/ros/ros_tutorials/issues/165>) (#166 <https://github.com/ros/ros_tutorials/issues/166>)
  On windows it will stay uppercase but shouldn't impact users compared to
  current situation
  (cherry picked from commit e2853cac87f0c62db6294e5bc351e5b52fcd1ae1)
  Co-authored-by: Mikael Arguedas <mailto:mikael.arguedas@gmail.com>
* Contributors: mergify[bot]
```
