### PR TITLE
rqt_image_view: 2.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -625,7 +625,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/rqt_image_view-release.git
-      version: 1.3.0-2
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `2.0.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/tgenovese/rqt_image_view-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.0-2`

## rqt_image_view

```
* Update cmake requirements (fix cmake derpecation +switch to cxx17) (#81 <https://github.com/ros-visualization/rqt_image_view/issues/81>)
* Replace rmw_qos_profile_t with rclcpp::QoS (#93 <https://github.com/ros-visualization/rqt_image_view/issues/93>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```
