### PR TITLE
rqt_image_view: 1.3.0-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -625,7 +625,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/rqt_image_view-release.git
-      version: 1.3.0-2
+      version: 1.3.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `1.3.0-3`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/tgenovese/rqt_image_view-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.0-2`

## rqt_image_view

```
* include cv_bridge.hpp instead of cv_bridge.h (#80 <https://github.com/ros-visualization/rqt_image_view/issues/80>)
* Contributors: Lucas Walter
```
