### PR TITLE
interactive_markers: 2.5.4-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -203,7 +203,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/interactive_markers-release.git
-      version: 2.5.4-2
+      version: 2.5.4-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `2.5.4-3`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/tgenovese/interactive_markers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.5.4-2`

## interactive_markers

```
* Shorten the length of a lambda. (#106 <https://github.com/ros-visualization/interactive_markers/issues/106>)
* Contributors: Chris Lalancette
```
