### PR TITLE
rqt_common_plugins: 1.2.0-5 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -641,7 +641,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/rqt_common_plugins-release.git
-      version: 1.2.0-4
+      version: 1.2.0-5
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `1.2.0-5`:

- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/tgenovese/rqt_common_plugins-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.0-4`

## rqt_common_plugins

```
* Remove unreleased plugins from rqt_common_plugins. (#465 <https://github.com/ros-visualization/rqt_common_plugins/issues/465>)
* Update maintainers (#464 <https://github.com/ros-visualization/rqt_common_plugins/issues/464>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic
```
