### PR TITLE
nmea_msgs: 2.1.0-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -319,7 +319,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tgenovese/nmea_msgs-release.git
-      version: 2.1.0-3
+      version: 2.1.0-4
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_msgs` to `2.1.0-4`:

- upstream repository: https://github.com/ros-drivers/nmea_msgs.git
- release repository: https://github.com/tgenovese/nmea_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.0-3`

## nmea_msgs

```
* Add GPVTG and GPZDA Sentences (#19 <https://github.com/evenator/nmea_msgs/issues/19>)
  GPVTG is useful for interpreting speed and heading.
  GPZDA is useful for syncing date and time.
* Add GPGST NMEA message (#18 <https://github.com/evenator/nmea_msgs/issues/18>)
  Add ROS2 message definition for GST NMEA sentences.
  See: #17 <https://github.com/evenator/nmea_msgs/issues/17>
  Co-authored-by: Nicolas Chleq
```
