### PR TITLE
hel_fot_control: 1.0.0 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8,6 +8,19 @@ release_platforms:
   ubuntu:
   - noble
 repositories:
+  hel_fot_control:
+    release:
+      packages:
+      - fot_control
+      tags:
+        release: version/{version}
+      url: DOES-NOT-EXIST
+      version: 1.0.0
+    source:
+      type: git
+      url: https://gitlab.vtti.vt.edu/hel/GeneralSoftware/sol4/hel-ros-fot-control.git
+      version: release/1.0
+    status: developed
   my_package:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `hel_fot_control` to `1.0.0`:

- upstream repository: https://gitlab.vtti.vt.edu/hel/GeneralSoftware/sol4/hel-ros-fot-control.git
- release repository: DOES-NOT-EXIST
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
